### PR TITLE
minimal websockets implementation, flexible http api

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
   "dependencies": {
     "JSONStream": "^0.10.0",
     "endoc": "https://github.com/deanlandolt/endoc/tarball/master",
-    "engine.io-stream": "^0.4.3",
-    "monotonic-timestamp": "0.0.9",
+    "multiplex": "^5.0.0",
     "paramify": "^0.1.2",
     "performance-now": "^0.2.0",
     "semver": "^4.3.3",
-    "split": "^0.3.2",
     "xtend": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
this changes the api so you need to do

``` js
// server
var server = http.createServer(endo.handleRequest);
var engine = Engine(function(con){
  con.pipe(endo.createStream()).pipe(con);
});
engine.attach(server, '/ws');
server.listen(PORT);

// client
var con = engine('/ws');
var plex = multiplex();
con.pipe(plex).pipe(con);

var response = plex.createStream('/some/url');
```

this way we decouple from the transport layer and support duplex streams.

TODO:
- [ ] i removed the header and status events from the websocket transport. do we really need to add them back?
- [ ] we need a client lib for endo, so we don't leak the detail that we're using multiplex internally
- [ ] there's no notion of HTTP verbs in the websocket implementation, so we could be waiting for data if the handler returns a duplex stream but the client only issues a GET request
- [ ] there's no JSONStream stringifying/parsing yet. i wasn't sure how to handle raw vs json streams here, so I left JSON serializing to the user
- [ ]  i didn't run this code, we could need tests or some simple examples
